### PR TITLE
Fix detection of protocol. url.protocol includes the colon (e.g. https:)

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ exports = module.exports = function(options) {
       // Create a HTTP connection handling function that can be retried
       function connect(u, retries, retryInterval) {
         var parsed = url.parse(u),
-          protocol = (parsed.protocol === 'https') ? https : http,
+          protocol = (parsed.protocol === 'https:') ? https : http,
           options = {
             port: parsed.port,
             hostname: parsed.hostname || 'localhost',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exec-wait",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Simple, promiseful execution utility for spawning processes and monitor that they really started.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
url.protocol includes the colon in protocol (e.g. http: / https:)
https detection was not working due to this.
